### PR TITLE
adjusted the vspc-v2 RPC data structure

### DIFF
--- a/rpc/core/src/model/acceptance_data.rs
+++ b/rpc/core/src/model/acceptance_data.rs
@@ -1,21 +1,23 @@
 use serde::{Deserialize, Serialize};
 use workflow_serializer::prelude::*;
 
-use super::{RpcHeader, RpcHeaderVerbosity, RpcTransaction, RpcTransactionVerbosity};
+use super::{RpcHeader, RpcHash, RpcHeaderVerbosity, RpcTransaction, RpcTransactionVerbosity};
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct RpcAcceptanceData {
     pub accepting_chain_header: Option<RpcHeader>,
     pub mergeset_block_acceptance_data: Vec<RpcMergesetBlockAcceptanceData>,
+    pub accepted_transactions: Vec<RpcTransaction>,
 }
 
 impl RpcAcceptanceData {
     pub fn new(
         accepting_chain_header: Option<RpcHeader>,
         mergeset_block_acceptance_data: Vec<RpcMergesetBlockAcceptanceData>,
+        accepted_transactions: Vec<RpcTransaction>,
     ) -> Self {
-        Self { accepting_chain_header, mergeset_block_acceptance_data }
+        Self { accepting_chain_header, mergeset_block_acceptance_data, accepted_transactions }
     }
 }
 
@@ -24,6 +26,7 @@ impl Serializer for RpcAcceptanceData {
         store!(u8, &1, writer)?;
         store!(Option<RpcHeader>, &self.accepting_chain_header, writer)?;
         serialize!(Vec<RpcMergesetBlockAcceptanceData>, &self.mergeset_block_acceptance_data, writer)?;
+        serialize!(Vec<RpcTransaction>, &self.accepted_transactions, writer)?;
 
         Ok(())
     }
@@ -34,8 +37,9 @@ impl Deserializer for RpcAcceptanceData {
         let _version = load!(u8, reader);
         let accepting_chain_header = load!(Option<RpcHeader>, reader)?;
         let mergeset_block_acceptance_data = deserialize!(Vec<RpcMergesetBlockAcceptanceData>, reader)?;
+        let accepted_transactions = deserialize!(Vec<RpcTransaction>, reader)?;
 
-        Ok(Self { accepting_chain_header, mergeset_block_acceptance_data })
+        Ok(Self { accepting_chain_header, mergeset_block_acceptance_data, accepted_transactions })
     }
 }
 
@@ -43,13 +47,13 @@ impl Deserializer for RpcAcceptanceData {
 #[serde(rename_all = "camelCase")]
 pub struct RpcMergesetBlockAcceptanceData {
     pub merged_header: Option<RpcHeader>,
-    pub accepted_transactions: Vec<RpcTransaction>,
+    pub transaction_ids: Vec<RpcHash>,
 }
 
 impl RpcMergesetBlockAcceptanceData {
     #[inline(always)]
-    pub fn new(merged_header: Option<RpcHeader>, accepted_transactions: Vec<RpcTransaction>) -> Self {
-        Self { merged_header, accepted_transactions }
+    pub fn new(merged_header: Option<RpcHeader>, transaction_ids: Vec<RpcHash>) -> Self {
+        Self { merged_header, transaction_ids }
     }
 }
 
@@ -58,7 +62,7 @@ impl Serializer for RpcMergesetBlockAcceptanceData {
         store!(u8, &1, writer)?;
 
         store!(Option<RpcHeader>, &self.merged_header, writer)?;
-        serialize!(Vec<RpcTransaction>, &self.accepted_transactions, writer)?;
+        store!(Vec<RpcHash>, &self.transaction_ids, writer)?;
 
         Ok(())
     }
@@ -69,9 +73,9 @@ impl Deserializer for RpcMergesetBlockAcceptanceData {
         let _version = load!(u8, reader);
 
         let merged_header = load!(Option<RpcHeader>, reader)?;
-        let accepted_transactions = deserialize!(Vec<RpcTransaction>, reader)?;
+        let transaction_ids = load!(Vec<RpcHash>, reader)?;
 
-        Ok(Self { merged_header, accepted_transactions })
+        Ok(Self { merged_header, transaction_ids })
     }
 }
 
@@ -79,29 +83,35 @@ impl Deserializer for RpcMergesetBlockAcceptanceData {
 #[serde(rename_all = "camelCase")]
 pub struct RpcAcceptanceDataVerbosity {
     pub accepting_chain_header_verbosity: Option<RpcHeaderVerbosity>,
-    pub mergeset_block_acceptance_data_verbosity: Option<RpcMergesetBlockAcceptanceDataVerbosity>,
+    pub merged_header_verbosity: Option<RpcHeaderVerbosity>,
+    pub accepted_transactions_verbosity: Option<RpcTransactionVerbosity>,
 }
 
 impl RpcAcceptanceDataVerbosity {
     pub fn new(
         accepting_chain_header_verbosity: Option<RpcHeaderVerbosity>,
-        mergeset_block_acceptance_data_verbosity: Option<RpcMergesetBlockAcceptanceDataVerbosity>,
+        merged_header_verbosity: Option<RpcHeaderVerbosity>,
+        accepted_transactions_verbosity: Option<RpcTransactionVerbosity>,
     ) -> Self {
-        Self { accepting_chain_header_verbosity, mergeset_block_acceptance_data_verbosity }
+        Self { accepting_chain_header_verbosity, merged_header_verbosity, accepted_transactions_verbosity }
     }
 
-    pub fn requires_merged_header(&self, default: bool) -> bool {
-        self.mergeset_block_acceptance_data_verbosity.as_ref().map_or(default, |active| active.requires_merged_header())
+    pub fn requires_merged_header(&self) -> bool {
+        self.merged_header_verbosity.is_some()
+            || self.accepted_transactions_verbosity.as_ref().is_some_and(|active| {
+                active.verbose_data_verbosity.as_ref().is_some_and(|active| active.include_block_hash.unwrap_or(false))
+            })
     }
 
-    pub fn requeires_accepted_header(&self, default: bool) -> bool {
-        self.mergeset_block_acceptance_data_verbosity.as_ref().map_or(default, |active| active.requires_merged_block_hash())
+    pub fn requeires_accepted_header(&self) -> bool {
+        self.merged_header_verbosity.as_ref().is_some_and(|active| active.include_hash.unwrap_or(false))
+            || self.accepted_transactions_verbosity.as_ref().is_some_and(|active| {
+                active.verbose_data_verbosity.as_ref().is_some_and(|active| active.include_block_hash.unwrap_or(false))
+            })
     }
 
-    pub fn requires_accepted_transactions(&self, default: bool) -> bool {
-        self.mergeset_block_acceptance_data_verbosity
-            .as_ref()
-            .map_or(default, |active| active.accepted_transactions_verbosity.is_some())
+    pub fn requires_accepted_transactions(&self) -> bool {
+        self.accepted_transactions_verbosity.as_ref().is_some()
     }
 }
 
@@ -109,7 +119,8 @@ impl Serializer for RpcAcceptanceDataVerbosity {
     fn serialize<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
         store!(u8, &1, writer)?;
         store!(Option<RpcHeaderVerbosity>, &self.accepting_chain_header_verbosity, writer)?;
-        serialize!(Option<RpcMergesetBlockAcceptanceDataVerbosity>, &self.mergeset_block_acceptance_data_verbosity, writer)?;
+        serialize!(Option<RpcHeaderVerbosity>, &self.merged_header_verbosity, writer)?;
+        serialize!(Option<RpcTransactionVerbosity>, &self.accepted_transactions_verbosity, writer)?;
 
         Ok(())
     }
@@ -119,60 +130,10 @@ impl Deserializer for RpcAcceptanceDataVerbosity {
     fn deserialize<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
         let _version = load!(u8, reader);
         let accepting_chain_header_verbosity = load!(Option<RpcHeaderVerbosity>, reader)?;
-        let mergeset_block_acceptance_data_verbosity = deserialize!(Option<RpcMergesetBlockAcceptanceDataVerbosity>, reader)?;
-
-        Ok(Self { accepting_chain_header_verbosity, mergeset_block_acceptance_data_verbosity })
-    }
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct RpcMergesetBlockAcceptanceDataVerbosity {
-    pub merged_header_verbosity: Option<RpcHeaderVerbosity>,
-    pub accepted_transactions_verbosity: Option<RpcTransactionVerbosity>,
-}
-
-impl RpcMergesetBlockAcceptanceDataVerbosity {
-    pub fn requires_merged_header(&self) -> bool {
-        self.merged_header_verbosity.is_some()
-            || self.accepted_transactions_verbosity.as_ref().is_some_and(|active| {
-                active.verbose_data_verbosity.as_ref().is_some_and(|active| active.include_block_hash.unwrap_or(false))
-            })
-    }
-
-    pub fn requires_merged_block_hash(&self) -> bool {
-        self.merged_header_verbosity.as_ref().is_some_and(|active| active.include_hash.unwrap_or(false))
-            || self.accepted_transactions_verbosity.as_ref().is_some_and(|active| {
-                active.verbose_data_verbosity.as_ref().is_some_and(|active| active.include_block_hash.unwrap_or(false))
-            })
-    }
-}
-
-impl RpcMergesetBlockAcceptanceDataVerbosity {
-    pub fn new(
-        merged_header_verbosity: Option<RpcHeaderVerbosity>,
-        accepted_transactions_verbosity: Option<RpcTransactionVerbosity>,
-    ) -> Self {
-        Self { merged_header_verbosity, accepted_transactions_verbosity }
-    }
-}
-
-impl Serializer for RpcMergesetBlockAcceptanceDataVerbosity {
-    fn serialize<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
-        store!(u8, &1, writer)?;
-        serialize!(Option<RpcHeaderVerbosity>, &self.merged_header_verbosity, writer)?;
-        serialize!(Option<RpcTransactionVerbosity>, &self.accepted_transactions_verbosity, writer)?;
-
-        Ok(())
-    }
-}
-
-impl Deserializer for RpcMergesetBlockAcceptanceDataVerbosity {
-    fn deserialize<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
-        let _version = load!(u8, reader)?;
         let merged_header_verbosity = deserialize!(Option<RpcHeaderVerbosity>, reader)?;
         let accepted_transactions_verbosity = deserialize!(Option<RpcTransactionVerbosity>, reader)?;
 
-        Ok(Self { merged_header_verbosity, accepted_transactions_verbosity })
+        Ok(Self { accepting_chain_header_verbosity, merged_header_verbosity, accepted_transactions_verbosity })
     }
 }
+

--- a/rpc/core/src/model/header.rs
+++ b/rpc/core/src/model/header.rs
@@ -420,6 +420,7 @@ pub struct RpcHeaderVerbosity {
     pub include_blue_work: Option<bool>,
     pub include_blue_score: Option<bool>,
     pub include_pruning_point: Option<bool>,
+    pub include_transaction_ids: Option<bool>,
 }
 
 impl Serializer for RpcHeaderVerbosity {
@@ -439,6 +440,7 @@ impl Serializer for RpcHeaderVerbosity {
         store!(Option<bool>, &self.include_blue_work, writer)?;
         store!(Option<bool>, &self.include_blue_score, writer)?;
         store!(Option<bool>, &self.include_pruning_point, writer)?;
+        store!(Option<bool>, &self.include_transaction_ids, writer)?;
 
         Ok(())
     }
@@ -461,6 +463,7 @@ impl Deserializer for RpcHeaderVerbosity {
         let include_blue_work = load!(Option<bool>, reader)?;
         let include_blue_score = load!(Option<bool>, reader)?;
         let include_pruning_point = load!(Option<bool>, reader)?;
+        let include_transaction_ids = load!(Option<bool>, reader)?;
 
         Ok(Self {
             include_hash,
@@ -476,6 +479,7 @@ impl Deserializer for RpcHeaderVerbosity {
             include_blue_work,
             include_blue_score,
             include_pruning_point,
+            include_transaction_ids,
         })
     }
 }

--- a/rpc/grpc/core/proto/rpc.proto
+++ b/rpc/grpc/core/proto/rpc.proto
@@ -989,10 +989,6 @@ message GetUtxoReturnAddressResponseMessage {
 
 message RpcAcceptanceDataVerbosity {
   optional RpcBlockHeaderVerbosity acceptingChainHeaderVerbosity = 1; // default is null
-  optional RpcMergesetBlockAcceptanceDataVerbosity mergesetBlockAcceptanceDataVerbosity = 20; // default is null
-}
-
-message RpcMergesetBlockAcceptanceDataVerbosity {
   optional RpcBlockHeaderVerbosity mergedHeaderVerbosity = 2; // default is null
   optional RpcTransactionVerbosity acceptedTransactionsVerbosity = 4; // default is null
 }
@@ -1011,6 +1007,7 @@ message RpcBlockHeaderVerbosity {
   optional bool includeBlueWork = 11; // default is false
   optional bool includePruningPoint = 12; // default is false
   optional bool includeBlueScore = 13; // default is false
+  optional bool includeTransactionIds = 14; // default is false
 }
 
 message RpcTransactionVerbosity {
@@ -1078,11 +1075,12 @@ message RpcUtxoEntryVerboseDataVerbosity {
 message RpcAcceptanceData {
   optional RpcBlockHeader acceptingChainHeader = 1;
   repeated RpcMergesetBlockAcceptanceData mergesetBlockAcceptanceData = 20;
+  repeated RpcTransaction acceptedTransactions = 21;
 }
 
 message RpcMergesetBlockAcceptanceData {
   optional RpcBlockHeader mergedHeader = 2;
-  repeated RpcTransaction acceptedTransactions = 3;
+  repeated string transactionIds = 4;
 }
 
 /// GetVirtualChainFromBlockV2RequestMessage requests the virtual selected

--- a/rpc/grpc/core/src/convert/acceptance_data.rs
+++ b/rpc/grpc/core/src/convert/acceptance_data.rs
@@ -1,6 +1,7 @@
 use crate::protowire::{self, RpcBlockHeaderVerbosity, RpcTransactionVerbosity};
 use crate::{from, try_from};
-use kaspa_rpc_core::{RpcError, RpcMergesetBlockAcceptanceData};
+use kaspa_rpc_core::{RpcError, RpcHash, RpcMergesetBlockAcceptanceData};
+use std::str::FromStr;
 
 // ----------------------------------------------------------------------------
 // rpc_core to protowire
@@ -14,27 +15,26 @@ from!(item: &kaspa_rpc_core::RpcAcceptanceData,  protowire::RpcAcceptanceData, {
             .iter()
             .map(protowire::RpcMergesetBlockAcceptanceData::from)
             .collect(),
+        accepted_transactions: item
+            .accepted_transactions
+            .iter()
+            .map(protowire::RpcTransaction::from)
+            .collect(),
     }
 });
 
 from!(item: &kaspa_rpc_core::RpcAcceptanceDataVerbosity, protowire::RpcAcceptanceDataVerbosity, {
     Self {
         accepting_chain_header_verbosity: item.accepting_chain_header_verbosity.as_ref().map(RpcBlockHeaderVerbosity::from),
-        mergeset_block_acceptance_data_verbosity: item.mergeset_block_acceptance_data_verbosity.as_ref().map(protowire::RpcMergesetBlockAcceptanceDataVerbosity::from),
+        merged_header_verbosity: item.merged_header_verbosity.as_ref().map(RpcBlockHeaderVerbosity::from),
+        accepted_transactions_verbosity: item.accepted_transactions_verbosity.as_ref().map(RpcTransactionVerbosity::from),
     }
 });
 
 from!(item: &kaspa_rpc_core::RpcMergesetBlockAcceptanceData, protowire::RpcMergesetBlockAcceptanceData, {
     Self {
         merged_header: item.merged_header.as_ref().map(protowire::RpcBlockHeader::from),
-        accepted_transactions: item.accepted_transactions.iter().map(protowire::RpcTransaction::from).collect(),
-    }
-});
-
-from!(item: &kaspa_rpc_core::RpcMergesetBlockAcceptanceDataVerbosity, protowire::RpcMergesetBlockAcceptanceDataVerbosity, {
-    Self {
-        merged_header_verbosity: item.merged_header_verbosity.as_ref().map(RpcBlockHeaderVerbosity::from),
-        accepted_transactions_verbosity: item.accepted_transactions_verbosity.as_ref().map(RpcTransactionVerbosity::from),
+        transaction_ids: item.transaction_ids.iter().map(|x| x.to_string()).collect(),
     }
 });
 
@@ -54,26 +54,25 @@ try_from!(item: &protowire::RpcAcceptanceData, kaspa_rpc_core::RpcAcceptanceData
         .iter()
         .map(RpcMergesetBlockAcceptanceData::try_from)
         .collect::<Result<_, _>>()?,
+        accepted_transactions: item.accepted_transactions.iter().map(kaspa_rpc_core::RpcTransaction::try_from).collect::<Result<_, _>>()?,
     }
 });
 
 try_from!(item: &protowire::RpcAcceptanceDataVerbosity, kaspa_rpc_core::RpcAcceptanceDataVerbosity, {
     Self {
         accepting_chain_header_verbosity: item.accepting_chain_header_verbosity.as_ref().map(kaspa_rpc_core::RpcHeaderVerbosity::try_from).transpose()?,
-        mergeset_block_acceptance_data_verbosity: item.mergeset_block_acceptance_data_verbosity.as_ref().map(kaspa_rpc_core::RpcMergesetBlockAcceptanceDataVerbosity::try_from).transpose()?,
+        merged_header_verbosity: item.merged_header_verbosity.as_ref().map(kaspa_rpc_core::RpcHeaderVerbosity::try_from).transpose()?,
+        accepted_transactions_verbosity: item.accepted_transactions_verbosity.as_ref().map(kaspa_rpc_core::RpcTransactionVerbosity::try_from).transpose()?,
     }
 });
 
 try_from!(item: &protowire::RpcMergesetBlockAcceptanceData, kaspa_rpc_core::RpcMergesetBlockAcceptanceData, {
     Self {
         merged_header: item.merged_header.as_ref().map(kaspa_rpc_core::RpcHeader::try_from).transpose()?,
-        accepted_transactions: item.accepted_transactions.iter().map(kaspa_rpc_core::RpcTransaction::try_from).collect::<Result<_, _>>()?,
-    }
-});
-
-try_from!(item: &protowire::RpcMergesetBlockAcceptanceDataVerbosity, kaspa_rpc_core::RpcMergesetBlockAcceptanceDataVerbosity, {
-    Self {
-        merged_header_verbosity: item.merged_header_verbosity.as_ref().map(kaspa_rpc_core::RpcHeaderVerbosity::try_from).transpose()?,
-        accepted_transactions_verbosity: item.accepted_transactions_verbosity.as_ref().map(kaspa_rpc_core::RpcTransactionVerbosity::try_from).transpose()?,
+        transaction_ids: item
+            .transaction_ids
+            .iter()
+            .map(|x| RpcHash::from_str(x))
+            .collect::<Result<Vec<kaspa_rpc_core::RpcHash>, faster_hex::Error>>()?,
     }
 });

--- a/rpc/grpc/core/src/convert/header.rs
+++ b/rpc/grpc/core/src/convert/header.rs
@@ -41,6 +41,7 @@ from!(item: &kaspa_rpc_core::RpcHeaderVerbosity, protowire::RpcBlockHeaderVerbos
         include_blue_work: item.include_blue_work,
         include_blue_score: item.include_blue_score,
         include_pruning_point: item.include_pruning_point,
+        include_transaction_ids: item.include_transaction_ids,
     }
 });
 
@@ -100,6 +101,7 @@ try_from!(item: &protowire::RpcBlockHeaderVerbosity, kaspa_rpc_core::RpcHeaderVe
         include_blue_work: item.include_blue_work,
         include_blue_score: item.include_blue_score,
         include_pruning_point: item.include_pruning_point,
+        include_transaction_ids: item.include_transaction_ids,
     }
 });
 

--- a/rpc/service/src/converter/consensus.rs
+++ b/rpc/service/src/converter/consensus.rs
@@ -1,7 +1,6 @@
 use async_trait::async_trait;
 use kaspa_addresses::{Address, AddressError};
 use kaspa_consensus_core::{
-    acceptance_data::MergesetBlockAcceptanceData,
     block::Block,
     config::Config,
     hashing::tx::hash,
@@ -21,7 +20,7 @@ use kaspa_notify::converter::Converter;
 use kaspa_rpc_core::{
     BlockAddedNotification, Notification, RpcAcceptanceData, RpcAcceptanceDataVerbosity, RpcAcceptedTransactionIds, RpcBlock,
     RpcBlockVerboseData, RpcError, RpcHash, RpcHeader, RpcHeaderVerbosity, RpcMempoolEntry, RpcMempoolEntryByAddress,
-    RpcMergesetBlockAcceptanceData, RpcMergesetBlockAcceptanceDataVerbosity, RpcResult, RpcTransaction, RpcTransactionInput,
+    RpcMergesetBlockAcceptanceData, RpcResult, RpcTransaction, RpcTransactionInput,
     RpcTransactionInputVerboseData, RpcTransactionInputVerboseDataVerbosity, RpcTransactionInputVerbosity, RpcTransactionOutput,
     RpcTransactionOutputVerboseData, RpcTransactionOutputVerboseDataVerbosity, RpcTransactionOutputVerbosity,
     RpcTransactionVerboseData, RpcTransactionVerboseDataVerbosity, RpcTransactionVerbosity, RpcUtxoEntry, RpcUtxoEntryVerboseData,
@@ -295,8 +294,8 @@ impl ConsensusConverter {
     fn get_transaction_verbose_data_with_verbosity(
         &self,
         transaction: &Transaction,
-        block_hash: Hash,
-        block_time: u64,
+        block_hash: Option<Hash>,
+        block_time: Option<u64>,
         compute_mass: u64,
         verbosity: &RpcTransactionVerboseDataVerbosity,
     ) -> RpcResult<RpcTransactionVerboseData> {
@@ -308,8 +307,8 @@ impl ConsensusConverter {
             },
             hash: if verbosity.include_hash.unwrap_or(false) { Some(hash(transaction, true)) } else { Default::default() },
             compute_mass: if verbosity.include_compute_mass.unwrap_or(false) { Some(compute_mass) } else { Default::default() },
-            block_hash: if verbosity.include_block_hash.unwrap_or(false) { Some(block_hash) } else { Default::default() },
-            block_time: if verbosity.include_block_time.unwrap_or(false) { Some(block_time) } else { Default::default() },
+            block_hash: if verbosity.include_block_hash.unwrap_or(false) { block_hash } else { Default::default() },
+            block_time: if verbosity.include_block_time.unwrap_or(false) { block_time } else { Default::default() },
         })
     }
 
@@ -420,15 +419,9 @@ impl ConsensusConverter {
             payload: if verbosity.include_payload.unwrap_or(false) { Some(transaction.payload.clone()) } else { Default::default() },
             mass: if verbosity.include_mass.unwrap_or(false) { Some(transaction.mass()) } else { Default::default() },
             verbose_data: if let Some(verbose_data_verbosity) = verbosity.verbose_data_verbosity.as_ref() {
-                let block_time = if let Some(block_time) = block_time {
-                    block_time
-                } else {
-                    consensus.async_get_header(block_hash.unwrap()).await?.timestamp
-                };
-
                 Some(self.get_transaction_verbose_data_with_verbosity(
                     transaction,
-                    block_hash.unwrap(),
+                    block_hash,
                     block_time,
                     consensus.calculate_transaction_non_contextual_masses(transaction).compute_mass,
                     verbose_data_verbosity,
@@ -476,18 +469,10 @@ impl ConsensusConverter {
             payload: Some(transaction.tx.payload.clone()),
             mass: Some(transaction.tx.mass()),
             verbose_data: if let Some(verbose_data_verbosity) = verbosity.verbose_data_verbosity.as_ref() {
-                let block_time = if let Some(block_time) = block_time {
-                    block_time
-                } else if let Some(block_hash) = block_hash {
-                    consensus.async_get_header(block_hash).await?.timestamp
-                } else {
-                    return Err(RpcError::ConsensusConverterNotFound("Block time not provided".to_string()));
-                };
-
                 Some(
                     self.get_transaction_verbose_data_with_verbosity(
                         &transaction.tx,
-                        block_hash.unwrap(),
+                        block_hash,
                         block_time,
                         transaction
                             .calculated_non_contextual_masses
@@ -507,8 +492,6 @@ impl ConsensusConverter {
         consensus: &ConsensusProxy,
         accepting_block_hash: RpcHash,
         tx_ids: Option<Vec<TransactionId>>,
-        mergeset_block_acceptance: &MergesetBlockAcceptanceData,
-        block_time: Option<u64>,
         verbosity: &RpcTransactionVerbosity,
     ) -> RpcResult<Vec<RpcTransaction>> {
         let txs = consensus
@@ -533,8 +516,8 @@ impl ConsensusConverter {
                             .convert_transaction_with_verbosity(
                                 consensus,
                                 tx,
-                                Some(mergeset_block_acceptance.block_hash),
-                                block_time,
+                                None,
+                                None,
                                 verbosity,
                             )
                             .await?;
@@ -558,8 +541,8 @@ impl ConsensusConverter {
                             .convert_signable_transaction_with_verbosity(
                                 consensus,
                                 tx,
-                                Some(mergeset_block_acceptance.block_hash),
-                                block_time,
+                                None,
+                                None,
                                 verbosity,
                             )
                             .await?;
@@ -577,42 +560,6 @@ impl ConsensusConverter {
         })
     }
 
-    async fn get_mergeset_block_acceptance_data_with_verbosity(
-        &self,
-        consensus: &ConsensusProxy,
-        accepting_chain_block: Hash,
-        mergeset_block_acceptance: &MergesetBlockAcceptanceData,
-        verbosity: &RpcMergesetBlockAcceptanceDataVerbosity,
-    ) -> RpcResult<RpcMergesetBlockAcceptanceData> {
-        let merged_header = if let Some(merged_header_verbosity) = verbosity.merged_header_verbosity.as_ref() {
-            let merged_header =
-                self.get_header_with_verbosity(consensus, merged_header_verbosity, mergeset_block_acceptance.block_hash).await?;
-            if merged_header.is_empty() {
-                Default::default()
-            } else {
-                Some(merged_header)
-            }
-        } else {
-            Default::default()
-        };
-
-        let accepted_txs = if let Some(accepted_transaction_verbosity) = verbosity.accepted_transactions_verbosity.as_ref() {
-            self.get_accepted_transactions_with_verbosity(
-                consensus,
-                accepting_chain_block,
-                None,
-                mergeset_block_acceptance,
-                merged_header.as_ref().and_then(|x| x.timestamp.as_ref().map(|ts| *ts)),
-                accepted_transaction_verbosity,
-            )
-            .await?
-        } else {
-            Vec::new()
-        };
-
-        Ok(RpcMergesetBlockAcceptanceData { merged_header, accepted_transactions: accepted_txs })
-    }
-
     pub async fn get_acceptance_data_with_verbosity(
         &self,
         consensus: &ConsensusProxy,
@@ -620,7 +567,7 @@ impl ConsensusConverter {
         chain_path: &ChainPath,
         merged_blocks_limit: Option<usize>,
     ) -> RpcResult<Vec<RpcAcceptanceData>> {
-        if verbosity.accepting_chain_header_verbosity.is_none() && verbosity.mergeset_block_acceptance_data_verbosity.is_none() {
+        if verbosity.accepting_chain_header_verbosity.is_none() && verbosity.merged_header_verbosity.is_none() && verbosity.accepted_transactions_verbosity.is_none() {
             // Early exit condition
             return Ok(Vec::new());
         }
@@ -640,29 +587,58 @@ impl ConsensusConverter {
                 Default::default()
             };
 
-            if let Some(mergeset_block_acceptance_data_verbosity) = verbosity.mergeset_block_acceptance_data_verbosity.as_ref() {
-                let mut rpc_mergeset_block_acceptance_data = Vec::with_capacity(acceptance_data.len());
+            let mergeset_block_acceptance_data = if let Some(verbosity) = verbosity.merged_header_verbosity.as_ref() {
+                let mut rpc_mergeset_block_acceptance_data = Vec::<RpcMergesetBlockAcceptanceData>::with_capacity(acceptance_data.len());
 
                 for mergeset_block_acceptance in acceptance_data.iter() {
-                    rpc_mergeset_block_acceptance_data.push(
-                        self.get_mergeset_block_acceptance_data_with_verbosity(
-                            consensus,
-                            *accepting_chain_hash,
-                            mergeset_block_acceptance,
-                            mergeset_block_acceptance_data_verbosity,
-                        )
-                        .await?,
-                    );
+                    let merged_header = self.get_header_with_verbosity(consensus, verbosity, mergeset_block_acceptance.block_hash).await?;
+                    if merged_header.is_empty() {
+                        rpc_mergeset_block_acceptance_data.push(RpcMergesetBlockAcceptanceData {
+                            merged_header: Default::default(),
+                            transaction_ids: Default::default(),
+                        });
+                    } else {
+                        let transaction_ids = if verbosity.include_transaction_ids.unwrap_or(false) {
+                            let block = consensus.async_get_block_even_if_header_only(mergeset_block_acceptance.block_hash).await?;
+                            block.transactions.iter().map(|x| x.id()).collect()
+                        } else {
+                            Vec::new()
+                        };
+                        rpc_mergeset_block_acceptance_data.push(RpcMergesetBlockAcceptanceData {
+                            merged_header: Some(merged_header),
+                            transaction_ids,
+                        });
+                    }
                 }
-
-                rpc_acceptance_data.push(RpcAcceptanceData {
-                    accepting_chain_header,
-                    mergeset_block_acceptance_data: rpc_mergeset_block_acceptance_data,
-                });
+                
+                rpc_mergeset_block_acceptance_data
+                
             } else {
-                rpc_acceptance_data
-                    .push(RpcAcceptanceData { accepting_chain_header, mergeset_block_acceptance_data: Default::default() });
+                Vec::new()
             };
+            
+            let accepted_transactions = if let Some(verbosity) = verbosity.accepted_transactions_verbosity.as_ref() {
+
+                self.get_accepted_transactions_with_verbosity(
+                    consensus,
+                    *accepting_chain_hash,
+                    None,
+                    verbosity,
+                )
+                .await?
+            
+                // TODO: block_hash/block_time in each accepted transaction ..
+
+            } else {
+                Vec::new()
+            };
+            
+            rpc_acceptance_data.push(RpcAcceptanceData {
+                accepting_chain_header,
+                mergeset_block_acceptance_data,
+                accepted_transactions,
+            });
+            
         }
         Ok(rpc_acceptance_data)
     }


### PR DESCRIPTION
Adjusted the RPC data structure so that "mergesetBlockAcceptanceData" no longer contains "acceptedTransactions" but makes them parallel, and added "transactionIds".

```
message RpcAcceptanceDataVerbosity {
  optional RpcBlockHeaderVerbosity acceptingChainHeaderVerbosity = 1;
  optional RpcBlockHeaderVerbosity mergedHeaderVerbosity = 2;
  optional RpcTransactionVerbosity acceptedTransactionsVerbosity = 4;
}

message RpcBlockHeaderVerbosity {
  // ..
  optional bool includeTransactionIds = 14;
}

// removed message RpcMergesetBlockAcceptanceDataVerbosity {..

message RpcAcceptanceData {
  optional RpcBlockHeader acceptingChainHeader = 1;
  repeated RpcMergesetBlockAcceptanceData mergesetBlockAcceptanceData = 20;
  repeated RpcTransaction acceptedTransactions = 21; // accepted tx data list in each vspcs
}

message RpcMergesetBlockAcceptanceData {
  optional RpcBlockHeader mergedHeader = 2;
  repeated string transactionIds = 4; // tx ids in each merged blocks (include unaccepted)
}

```
TODO: Add block_hash/block_time to each accepted transaction..
TODO: Maybe need to evaluate the appropriate batch_size.
